### PR TITLE
feature/issues-1: Load default config file from project dir if no given by cli argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +426,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +447,7 @@ name = "gpti"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "directories",
  "openai",
  "serde",
  "spinners",
@@ -588,6 +621,17 @@ name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -780,6 +824,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +901,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.4.13", features = ["derive", "env"] }
+directories = "5.0.1"
 openai = "1.0.0-alpha.13"
 serde = "1.0.195"
 spinners = "4.1.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,90 @@
+use std::io::Error;
+use crate::yesno::ask_yes_no; // Update the import statement to reflect the changes in Rust 2018 module system
+
+use directories::ProjectDirs;
+
+
+pub struct Config{
+    pub path: String,
+}
+
+impl Config {
+    pub fn new(path: Option<String>) -> Self {
+
+        // If path is provided, use it
+        if let Some(path) = path {
+            return Self { path };
+        }
+
+        // If path is not provided, use default 
+        let default_path = Self::default_path().unwrap();
+        Self { path: default_path }
+
+    }
+
+    pub fn default_path() -> Result<String, Error> {
+        match ProjectDirs::from("tools", "cli",  "gpti") {
+            Some(proj_dirs) => {
+                let config_dir = proj_dirs.config_dir().to_str().unwrap();
+                let path = format!("{}/gpti.toml", config_dir);
+                Ok(path)
+            },
+            None => Err(Error::new(std::io::ErrorKind::Other, "Could not find config directory"))
+        }
+    }
+
+    pub fn create_default(&self) -> Result<(), Error> {
+        let msg = format!(r#"
+        Config file not found at: {}
+        It may be the first time you're running this program.
+        I can help you with that by creating a default config file for you.
+        Or you can give a path to an existing config file with the --config flag.
+        Do you want me to create a default config file?
+        "#, self.path);
+
+        let create_file = ask_yes_no(&msg);
+
+        if create_file{
+            let path = std::path::Path::new(&self.path);
+            let parent = path.parent().unwrap();
+            std::fs::create_dir_all(parent)?;
+
+            let config_path = Self::get_default_config();
+            match std::fs::write(&self.path, config_path) {
+                Ok(_) => {
+                    println!("Config file created at: {}", self.path);
+                    println!("Please add your OpenAI API key to the config file and try again.");
+                    Ok(())
+                }
+                ,
+                Err(e) => {
+                    Err(e)
+                }
+            }
+        } else {
+            println!("No config file created, exiting...");
+            Ok(())
+        }
+    }
+
+    fn get_default_config() -> String {
+        let default_config = r#"
+[openai]
+api_key = ""
+
+[[prompts]]
+name = "test"
+text = "This is a test prompt"
+description = "this is a test prompt"
+"#;
+
+        default_config.to_string()
+    }
+
+    pub fn doesnt_exists(&self) -> bool { 
+        match std::fs::metadata(&self.path) {
+            Ok(_) => false,
+            Err(_) => true,
+        }
+    }
+}

--- a/src/yesno.rs
+++ b/src/yesno.rs
@@ -1,0 +1,7 @@
+pub fn ask_yes_no(prompt: &str) -> bool {
+    println!("{}", prompt);
+    println!("Type y or yes to confirm, anything else to cancel.");
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input).unwrap();
+    input.trim() == "y" || input.trim() == "yes"
+}


### PR DESCRIPTION
Implements https://github.com/edvm/GPTi/issues/1

Now:
- It still accepts a path to a config file using `-c` cli argument
- If no `-c` cli argument is given, it tries to find the config file at default project locations. Project locations depend on running OS (for ex, Mac is `Users/<username>/Library/Application Support/`. If no config file is found, it asks the user to create a default one.